### PR TITLE
Add spinners, reformat code, reimplement hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ workspace.code-workspace
 *.svg
 *.data
 *.data.old
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,12 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "console"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,17 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "indicatif"
 version = "0.17.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,12 +108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
 name = "pq-sys"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,46 +132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -271,12 +208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "text_io"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee74b5019b48991b09803402aaf9e65a053b3993fe9d9c475ab67a395358ba76"
-
-[[package]]
 name = "tlm"
 version = "0.1.0"
 dependencies = [
@@ -284,11 +215,9 @@ dependencies = [
  "diesel",
  "indicatif",
  "lazy_static",
- "rand",
  "regex",
  "seahash",
  "serde",
- "text_io",
  "toml",
  "walkdir",
 ]
@@ -324,12 +253,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "console"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "terminal_size",
+ "winapi",
+]
+
+[[package]]
 name = "diesel"
 version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +72,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +86,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500f7e5a63596852b9bf7583fe86f9ad08e0df9b4eb58d12e9729071cb4952ca"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
 ]
 
 [[package]]
@@ -86,6 +117,12 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "ppv-lite86"
@@ -224,6 +261,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "text_io"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +282,7 @@ version = "0.1.0"
 dependencies = [
  "argparse",
  "diesel",
+ "indicatif",
  "lazy_static",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,10 @@ edition = "2018"
 [dependencies]
 walkdir = "2"
 regex = "1"
-rand = "0.8.4"
 argparse = "0.2.2"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5.8"
 diesel = { version = "1.4.7", features = ["postgres"] }
 seahash = "4.1.0"
 lazy_static = "1.4.0"
-text_io = "0.1.9"
 indicatif = "0.17.0-beta.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ diesel = { version = "1.4.7", features = ["postgres"] }
 seahash = "4.1.0"
 lazy_static = "1.4.0"
 text_io = "0.1.9"
+indicatif = "0.17.0-beta.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,7 +79,7 @@ impl Config {
             }
         }
 
-        return config;
+        config
     }
 }
 
@@ -98,9 +98,8 @@ pub struct Preferences {
     pub min_verbosity: Verbosity,
     pub disable_input: bool,
 }
-
-impl Preferences {
-    pub fn new() -> Preferences {
+impl Default for Preferences {
+    fn default() -> Preferences {
         let mut prepare = Preferences {
             default_print: true,
             print_content: false,
@@ -118,9 +117,11 @@ impl Preferences {
 
         prepare.parse_arguments();
 
-        return prepare;
+        prepare
     }
+}
 
+impl Preferences {
     ///Parses command line arguments using arg parse
     fn parse_arguments(&mut self) {
         let mut parser = ArgumentParser::new();

--- a/src/database.rs
+++ b/src/database.rs
@@ -11,14 +11,12 @@ use std::env;
 ///Sets up a connection to the database via DATABASE_URL environment variable
 pub fn establish_connection() -> PgConnection {
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    PgConnection::establish(&database_url).expect(&format!("Error connecting to {}", database_url))
+    PgConnection::establish(&database_url)
+        .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
 }
 
 ///Inserts content data into the database
-pub fn create_contents<'a>(
-    conn: &PgConnection,
-    new_contents: Vec<NewContent>,
-) -> Vec<ContentModel> {
+pub fn create_contents(conn: &PgConnection, new_contents: Vec<NewContent>) -> Vec<ContentModel> {
     diesel::insert_into(content_table::table)
         .values(&new_contents)
         .get_results(conn)
@@ -26,8 +24,8 @@ pub fn create_contents<'a>(
 }
 
 ///Inserts show data into the database
-pub fn create_show<'a>(conn: &PgConnection, title: String) -> ShowModel {
-    let new_show = NewShow { title: title };
+pub fn create_show(conn: &PgConnection, title: String) -> ShowModel {
+    let new_show = NewShow { title };
 
     diesel::insert_into(show_table::table)
         .values(&new_show)
@@ -36,7 +34,7 @@ pub fn create_show<'a>(conn: &PgConnection, title: String) -> ShowModel {
 }
 
 ///Inserts episode data into the database
-pub fn create_episodes<'a>(conn: &PgConnection, new_episode: Vec<NewEpisode>) -> Vec<EpisodeModel> {
+pub fn create_episodes(conn: &PgConnection, new_episode: Vec<NewEpisode>) -> Vec<EpisodeModel> {
     diesel::insert_into(episode_table::table)
         .values(&new_episode)
         .get_results(conn)
@@ -49,8 +47,7 @@ pub fn get_all_content(utility: Utility) -> Vec<ContentModel> {
     let connection = establish_connection();
 
     utility.print_function_timer();
-    let data = content_data
+    content_data
         .load::<ContentModel>(&connection)
-        .expect("Error loading content");
-    return data;
+        .expect("Error loading content")
 }

--- a/src/designation.rs
+++ b/src/designation.rs
@@ -7,17 +7,9 @@ pub enum Designation {
 
 pub fn convert_i32_to_designation(input: i32) -> Designation {
     match input {
-        1 => {
-            return Designation::Generic;
-        }
-        2 => {
-            return Designation::Episode;
-        }
-        3 => {
-            return Designation::Movie;
-        }
-        _ => {
-            return Designation::Generic;
-        }
+        1 => Designation::Generic,
+        2 => Designation::Episode,
+        3 => Designation::Movie,
+        _ => Designation::Generic,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 use tlm::{
     config::Config,
-    scheduler::{ImportFiles, ProcessNewFiles, Scheduler, Task, TaskType, Test},
+    scheduler::{Hash, ImportFiles, ProcessNewFiles, Scheduler, Task, TaskType, Test},
     utility::Utility,
 };
 
@@ -44,6 +44,7 @@ fn main() {
         ))));
 
         tasks_guard.push_back(Task::new(TaskType::ProcessNewFiles(ProcessNewFiles::new())));
+        tasks_guard.push_back(Task::new(TaskType::Hash(Hash::new())))
     }
 
     //Placeholder user input

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 use tlm::{
     config::Config,
-    scheduler::{Hash, ImportFiles, ProcessNewFiles, Scheduler, Task, TaskType, Test},
+    scheduler::{Hash, ImportFiles, ProcessNewFiles, Scheduler, Task, TaskType},
     utility::Utility,
 };
 
@@ -10,7 +10,6 @@ use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use text_io::read;
 
 fn main() {
     //traceback and timing utility
@@ -57,25 +56,6 @@ fn main() {
         tasks_guard.push_back(Task::new(TaskType::ProcessNewFiles(ProcessNewFiles::new(
             process_bar,
         ))));
-    }
-
-    //Placeholder user input
-    if !utility.preferences.disable_input {
-        println!("Enter -1 to stop");
-        loop {
-            let input: i32 = read!();
-            if input == -1 {
-                break;
-            }
-
-            {
-                let mut tasks_guard = tasks.lock().unwrap();
-                tasks_guard.push_back(Task::new(TaskType::Test(Test::new(&format!(
-                    "Entered: {}",
-                    input
-                )))));
-            }
-        }
     }
 
     stop_scheduler.store(true, Ordering::Relaxed);

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,10 @@ fn main() {
             &config.ignored_paths,
         ))));
 
-        tasks_guard.push_back(Task::new(TaskType::ProcessNewFiles(ProcessNewFiles::new())));
-        tasks_guard.push_back(Task::new(TaskType::Hash(Hash::new())))
+        tasks_guard.push_back(Task::new(TaskType::ProcessNewFiles(
+            ProcessNewFiles::default(),
+        )));
+        tasks_guard.push_back(Task::new(TaskType::Hash(Hash::default())))
     }
 
     //Placeholder user input
@@ -77,5 +79,5 @@ fn main() {
         .print_number_of_shows(utility.clone());
 
     scheduler.file_manager.print_shows(utility.clone());
-    scheduler.file_manager.print_content(utility.clone());
+    scheduler.file_manager.print_content(utility);
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -54,7 +54,7 @@ impl FileManager {
         file_manager.tracked_directories = config.tracked_directories.clone();
 
         utility.print_function_timer();
-        return file_manager;
+        file_manager
     }
 
     pub fn print_number_of_content(&self, utility: Utility) {
@@ -104,7 +104,7 @@ impl FileManager {
         }
 
         utility.print_function_timer();
-        return content;
+        content
     }
 
     pub fn process_new_files(&mut self, utility: Utility) {
@@ -118,11 +118,9 @@ impl FileManager {
         let mut temp_content = Vec::new();
 
         //Create Content and NewContent that will be added to the database in a batch
-        while self.new_files_queue.len() > 0 {
+        while !self.new_files_queue.is_empty() {
             let current = self.new_files_queue.pop();
-            if current.is_some() {
-                let current = current.unwrap();
-
+            if let Some(current) = current {
                 let content = Content::new(
                     &current,
                     &mut self.tv.working_shows,
@@ -174,20 +172,20 @@ impl FileManager {
     //Hash set guarentees no duplicates in O(1) time
     pub fn import_files(
         &mut self,
-        allowed_extensions: &Vec<String>,
-        ignored_paths: &Vec<String>,
+        allowed_extensions: &[String],
+        ignored_paths: &[String],
         utility: Utility,
     ) {
         let mut utility = utility.clone_add_location("import_files(FileManager)");
 
         //Return true if string contains any substring from Vector
-        fn str_contains_strs(input_str: &str, substrings: &Vec<String>) -> bool {
+        fn str_contains_strs(input_str: &str, substrings: &[String]) -> bool {
             for substring in substrings {
                 if String::from(input_str).contains(&substring.to_lowercase()) {
                     return true;
                 }
             }
-            return false;
+            false
         }
 
         //import all files in tracked root directories
@@ -216,10 +214,10 @@ impl FileManager {
     }
 
     pub fn print_shows(&self, utility: Utility) {
-        Show::print_shows(&self.tv.working_shows, utility.clone());
+        Show::print_shows(&self.tv.working_shows, utility);
     }
 
     pub fn print_content(&self, utility: Utility) {
-        Content::print_content(&self.working_content, utility.clone());
+        Content::print_content(&self.working_content, utility);
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -19,12 +19,12 @@ pub struct ContentModel {
 
 impl ContentModel {
     pub fn from_content(c: Content) -> ContentModel {
-        return ContentModel {
+        ContentModel {
             id: c.content_uid.unwrap() as i32,
             full_path: c.get_full_path(),
             designation: c.designation as i32,
             file_hash: c.hash,
-        };
+        }
     }
 }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,4 +1,5 @@
 use crate::utility::Utility;
+use std::fmt;
 use std::num::ParseIntError;
 use std::str::FromStr;
 
@@ -29,9 +30,9 @@ pub enum From {
     Scheduler = 12,
 }
 
-impl From {
-    pub fn to_string(self) -> String {
-        String::from(match self {
+impl fmt::Display for From {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let string = match self {
             From::Main => "main",
             From::Lib => "lib",
             From::Content => "content",
@@ -44,20 +45,22 @@ impl From {
             From::Scheduler => "scheduler",
             From::TV => "tv",
             _ => "notset",
-        })
+        };
+        write!(f, "{}", string)
     }
 }
 
-impl Verbosity {
-    pub fn to_string(self) -> String {
-        String::from(match self {
+impl fmt::Display for Verbosity {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let string = match self {
             Verbosity::CRITICAL => "CRITICAL",
             Verbosity::ERROR => "ERROR",
             Verbosity::WARNING => "WARNING",
             Verbosity::INFO => "INFO",
             Verbosity::DEBUG => "DEBUG",
             _ => "NOTSET",
-        })
+        };
+        write!(f, "{}", string)
     }
 }
 
@@ -103,7 +106,7 @@ pub fn print(
                 string
             );
         } else {
-            call_functions_string = format!("{}", utility.traceback[utility.traceback.len() - 1]);
+            call_functions_string = utility.traceback[utility.traceback.len() - 1].to_string();
             println!(
                 "[{}][{}][{}]::{}",
                 verbosity.to_string(),

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -21,11 +21,11 @@ pub struct Profile {
 
 impl Profile {
     pub fn new(width: usize, height: usize, framerate: usize, length_time: usize) -> Self {
-        return Profile {
-            width: width,
-            height: height,
-            framerate: framerate,
-            length_time: length_time,
-        };
+        Profile {
+            width,
+            height,
+            framerate,
+            length_time,
+        }
     }
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -6,7 +6,7 @@ pub enum ResolutionStandard {
     ED,
     SD,
 }
-
+#[allow(dead_code)]
 pub struct EncodingProfile {
     resolution_standard: ResolutionStandard,
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -150,32 +150,6 @@ impl Encode {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct Test {
-    test_string: String,
-}
-
-impl Test {
-    pub fn new(test_string: &str) -> Self {
-        Test {
-            test_string: String::from(test_string),
-        }
-    }
-
-    pub fn run(&self, utility: Utility) {
-        let utility = utility.clone_add_location("run(Test)");
-        let wait_time = time::Duration::from_secs(2); //Just to illustrate threadedness
-        thread::sleep(wait_time);
-        print(
-            Verbosity::INFO,
-            From::Scheduler,
-            self.test_string.to_string(),
-            false,
-            utility,
-        );
-    }
-}
-
 pub struct Hash {
     pub progress_bar: ProgressBar,
 }
@@ -228,7 +202,6 @@ pub enum TaskType {
     Encode(Encode),
     ImportFiles(ImportFiles),
     ProcessNewFiles(ProcessNewFiles),
-    Test(Test),
     Hash(Hash),
 }
 
@@ -261,9 +234,6 @@ impl Task {
             }
             TaskType::ProcessNewFiles(process_new_files) => {
                 process_new_files.run(file_manager, utility);
-            }
-            TaskType::Test(test) => {
-                test.run(utility);
             }
             TaskType::Hash(hash) => {
                 return Some(hash.run(file_manager.working_content.clone()));

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -16,12 +16,12 @@ pub struct Timer {
 
 impl Timer {
     pub fn create_timer(uid: usize, function_name: String) -> Timer {
-        return Timer {
-            uid: uid,
-            function_name: function_name,
+        Timer {
+            uid,
+            function_name,
             timer: Instant::now(),
             stored_time: None,
-        };
+        }
     }
 
     pub fn store_timing(&mut self) {

--- a/src/tv.rs
+++ b/src/tv.rs
@@ -17,9 +17,9 @@ impl TV {
     pub fn new(utility: Utility) -> TV {
         let utility = utility.clone_add_location("new(TV)");
 
-        return TV {
-            working_shows: Show::get_all_shows(utility.clone()),
-        };
+        TV {
+            working_shows: Show::get_all_shows(utility),
+        }
     }
 }
 
@@ -32,10 +32,7 @@ pub struct Season {
 impl Season {
     pub fn new(number: usize) -> Season {
         let episodes = Vec::new();
-        Season {
-            number: number,
-            episodes: episodes,
-        }
+        Season { number, episodes }
     }
 
     pub fn insert_in_order(&mut self, c: Content) {
@@ -76,7 +73,7 @@ impl Show {
 
     pub fn show_exists(
         show_title: String,
-        working_shows: &Vec<Show>,
+        working_shows: &[Show],
         utility: Utility,
     ) -> Option<usize> {
         let mut utility = utility.clone_add_location("show_exists(Show)");
@@ -87,7 +84,7 @@ impl Show {
         }
 
         utility.print_function_timer();
-        return None;
+        None
     }
 
     pub fn ensure_show_exists(
@@ -100,7 +97,7 @@ impl Show {
 
         let show_uid = Show::show_exists(show_title.clone(), working_shows, utility.clone());
         match show_uid {
-            Some(uid) => return uid,
+            Some(uid) => uid,
             None => {
                 if utility.preferences.print_shows || utility.preferences.show_output_whitelisted {
                     print(
@@ -108,7 +105,7 @@ impl Show {
                         From::TV,
                         format!("Adding a new show: {}", show_title),
                         utility.preferences.show_output_whitelisted,
-                        utility.clone(),
+                        utility,
                     );
                 }
 
@@ -116,13 +113,13 @@ impl Show {
 
                 let show_uid = show_model.show_uid as usize;
                 let new_show = Show {
-                    show_uid: show_uid,
-                    title: show_title.clone(),
+                    show_uid,
+                    title: show_title,
                     seasons: Vec::new(),
                 };
                 working_shows.push(new_show);
 
-                return show_uid;
+                show_uid
             }
         }
     }
@@ -140,7 +137,7 @@ impl Show {
         };
         utility.print_function_timer();
 
-        return show;
+        show
     }
 
     pub fn get_all_shows(utility: Utility) -> Vec<Show> {
@@ -157,10 +154,10 @@ impl Show {
         }
 
         utility.print_function_timer();
-        return shows;
+        shows
     }
 
-    pub fn print_shows(shows: &Vec<Show>, utility: Utility) {
+    pub fn print_shows(shows: &[Show], utility: Utility) {
         let mut utility = utility.clone_add_location("print_shows(FileManager)");
 
         if !utility.preferences.print_shows {

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -3,6 +3,7 @@ use crate::{
     print::{print, From, Verbosity},
     timer::Timer,
 };
+use std::fmt;
 
 #[derive(Clone, Debug)]
 pub struct Utility {
@@ -18,16 +19,13 @@ impl Utility {
             traceback: Vec::new(),
             current_location: String::from(created_from),
             function_timer: None,
-            preferences: Preferences::new(),
+            preferences: Preferences::default(),
         };
-        return utility.add_traceback_location(created_from);
+        utility.add_traceback_location(created_from)
     }
 
     pub fn start_function_timer(&mut self) {
-        self.function_timer = Some(Timer::create_timer(
-            0,
-            String::from(self.current_location.clone()),
-        ));
+        self.function_timer = Some(Timer::create_timer(0, self.current_location.clone()));
     }
 
     pub fn print_function_timer(&mut self) {
@@ -44,7 +42,7 @@ impl Utility {
             print(
                 Verbosity::CRITICAL,
                 From::Utility,
-                format!("You tried to print a timer that doesn't exist."),
+                "You tried to print a timer that doesn't exist.".to_string(),
                 false,
                 self.clone(),
             );
@@ -54,7 +52,7 @@ impl Utility {
 
     fn add_traceback_location(&mut self, called_from: &str) -> Utility {
         self.traceback.push(String::from(called_from));
-        return self.clone();
+        self.clone()
     }
 
     pub fn clone_add_location(&self, called_from: &str) -> Utility {
@@ -64,10 +62,12 @@ impl Utility {
         if self.preferences.timing_enabled {
             temp.start_function_timer();
         }
-        return temp;
+        temp
     }
+}
 
-    pub fn to_string(&self) -> String {
+impl fmt::Display for Utility {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut call_functions_string: String = String::new();
         let mut single_execute_done = false;
         for function in &self.traceback {
@@ -78,6 +78,6 @@ impl Utility {
                 call_functions_string += &format!(">'{}'", function);
             }
         }
-        return call_functions_string;
+        write!(f, "{}", call_functions_string)
     }
 }


### PR DESCRIPTION
# Note
## I am happy to merge this after @alexipeck finishes converting all the code he's working on as it'll be easier for me to merge the changes into that branch than to rebase all of your code
# Changes

* Adds some nice spinners to show import, process and hash process. Will be used for encode later if we can find a nice way to implement it uses indicatif [repo](https://github.com/mitsuhiko/indicatif), [docs](https://docs.rs/indicatif/0.17.0-beta.1/indicatif/index.html)
* * Keep in mind I'm not using the stable verison of indicatif because multiline outputs wouldn't work
* Formats existing code in compliance with clippy
* * That includes getting rid of that ridiculous for loop that runs one guaranteed from ages ago that I though was already replaced
* Re-implements hash which addresses #10
* Reduces the number of arguments required for Async tasks by using the same AtomicBool to signal that the thread is stopped and to signal the thread to stop
