### PR TITLE
Remove import bar, remove utility from get_shows

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -85,7 +85,7 @@ pub fn get_all_shows(utility: Utility) -> Vec<Show> {
 
     for episode_model in episode_models {
         for generic in &generics {
-            if generic.get_generic_uid(utility.clone()) == episode_model.generic_uid as usize {
+            if generic.get_generic_uid() == episode_model.generic_uid as usize {
                 let episode = Episode::new(
                     generic.clone(),
                     episode_model.show_uid as usize,

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -163,20 +163,12 @@ impl Generic {
         return self.full_path.as_os_str().to_str().unwrap().to_string();
     }
 
-    pub fn get_generic_uid(&self, utility: Utility) -> usize {
-        let utility = utility.clone_add_location("get_generic_uid(Generic)");
-
+    #[inline(always)]
+    pub fn get_generic_uid(&self) -> usize {
         if self.generic_uid.is_some() {
             self.generic_uid.unwrap()
         } else {
-            print(
-                Verbosity::CRITICAL,
-                From::Generic,
-                String::from("get_generic_uid was called on a generic that hasn't been inserted into the db yet or hasn't been assigned a generic_uid from the database correctly"),
-                false,
-                utility,
-            );
-            panic!();
+            panic!("get_generic_uid was called on a generic that hasn't been inserted into the db yet or hasn't been assigned a generic_uid from the database correctly");
         }
     }
 
@@ -191,7 +183,7 @@ impl Generic {
             From::Generic,
             format!(
                 "[generic_uid:'{:4}'][designation:'{}'][full_path:'{}']",
-                self.get_generic_uid(utility.clone()),
+                self.get_generic_uid(),
                 self.designation as i32,
                 self.get_full_path(),
             ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,13 +23,11 @@ fn main() {
         .with_key("eta", |state| format!("{:.1}s", state.eta().as_secs_f64()))
         .progress_chars("#>-");
 
-    let import_bar = progress_bars.add(ProgressBar::new(0).with_style(style.clone()));
     let process_bar = progress_bars.add(ProgressBar::new(0).with_style(style.clone()));
     let hash_bar = progress_bars.add(ProgressBar::new(0).with_style(style));
 
     hash_bar.set_prefix("Hashing");
     process_bar.set_prefix("Processing");
-    import_bar.set_prefix("Importing");
 
     let config: Config = Config::new(&utility.preferences);
 
@@ -59,7 +57,6 @@ fn main() {
         tasks_guard.push_back(Task::new(TaskType::ImportFiles(ImportFiles::new(
             &config.allowed_extensions,
             &config.ignored_paths,
-            import_bar,
         ))));
 
         tasks_guard.push_back(Task::new(TaskType::ProcessNewFiles(ProcessNewFiles::new(
@@ -79,9 +76,15 @@ fn main() {
 
     let scheduler = scheduler_handle.join().unwrap();
 
-    scheduler.file_manager.print_number_of_generics(utility.clone());
-    scheduler.file_manager.print_number_of_shows(utility.clone());
-    scheduler.file_manager.print_number_of_episodes(utility.clone());
+    scheduler
+        .file_manager
+        .print_number_of_generics(utility.clone());
+    scheduler
+        .file_manager
+        .print_number_of_shows(utility.clone());
+    scheduler
+        .file_manager
+        .print_number_of_episodes(utility.clone());
     scheduler.file_manager.print_shows(utility.clone());
     scheduler.file_manager.print_generics(utility.clone());
     scheduler.file_manager.print_episodes(utility);

--- a/src/model.rs
+++ b/src/model.rs
@@ -13,12 +13,17 @@ pub struct NewGeneric {
     pub length_time: Option<f64>,
 }
 
-fn profile_is_some_split(profile: Option<Profile>) -> (Option<i32>, Option<i32>, Option<f64>, Option<f64>) {
-    if profile.is_some() {
-        let profile = profile.unwrap();
-        (Some(profile.width as i32), Some(profile.height as i32), Some(profile.framerate), Some(profile.length_time))
-    } else {
-        (None, None, None, None)
+fn profile_is_some_split(
+    profile: Option<Profile>,
+) -> (Option<i32>, Option<i32>, Option<f64>, Option<f64>) {
+    match profile {
+        Some(profile) => (
+            Some(profile.width as i32),
+            Some(profile.height as i32),
+            Some(profile.framerate),
+            Some(profile.length_time),
+        ),
+        None => (None, None, None, None),
     }
 }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -31,32 +31,21 @@ pub struct ImportFiles {
 
     pub status_underway: bool,
     pub status_completed: bool,
-    pub progress_bar: ProgressBar,
 }
 
 impl ImportFiles {
-    pub fn new(
-        allowed_extensions: &[String],
-        ignored_paths: &[String],
-        progress_bar: ProgressBar,
-    ) -> Self {
+    pub fn new(allowed_extensions: &[String], ignored_paths: &[String]) -> Self {
         ImportFiles {
             allowed_extensions: allowed_extensions.to_owned(),
             ignored_paths: ignored_paths.to_owned(),
             status_underway: false,
             status_completed: false,
-            progress_bar,
         }
     }
 
     pub fn run(&mut self, file_manager: &mut FileManager, utility: Utility) {
         self.status_underway = true;
-        file_manager.import_files(
-            &self.allowed_extensions,
-            &self.ignored_paths,
-            &self.progress_bar,
-            utility,
-        );
+        file_manager.import_files(&self.allowed_extensions, &self.ignored_paths, utility);
         self.status_completed = true;
     }
 }

--- a/src/show.rs
+++ b/src/show.rs
@@ -67,7 +67,7 @@ impl Episode {
             From::Show,
             format!(
                 "[generic_uid:'{:4}'][show_uid:'{:2}'][season:'{:2}'][episode:'{:2}'][full_path:'{}'][show_title:'{}']",
-                self.generic.get_generic_uid(utility.clone()),
+                self.generic.get_generic_uid(),
                 self.show_uid,
                 self.show_season,
                 self.get_episode_string(),


### PR DESCRIPTION
## Reasons
Import bar was so fast it wasn't needed. get_all_shows spent 2 seconds just cloning utility for every generic in the database

## Demonstration
### No modification
![image](https://user-images.githubusercontent.com/12377096/132296226-04b8c9b8-3921-4962-8e28-f569c4eca9cb.png)
```
❯ hyperfine -w 1 -r 100 "./target/release/tlm --no-input"
Benchmark #1: ./target/release/tlm --no-input
  Time (mean ± σ):      2.143 s ±  0.058 s    [User: 2.121 s, System: 0.013 s]
  Range (min … max):    2.078 s …  2.597 s    100 runs
```

### With modification
![image](https://user-images.githubusercontent.com/12377096/132296326-89785204-90df-4fbb-935e-0ff19380066d.png)
```
❯ hyperfine -w 1 -r 100 "./target/release/tlm --no-input"
Benchmark #1: ./target/release/tlm --no-input
  Time (mean ± σ):      39.0 ms ±   0.6 ms    [User: 21.9 ms, System: 8.8 ms]
  Range (min … max):    37.9 ms …  41.0 ms    100 runs
  ```