### PR TITLE
Fix a file import issue with files that have no extension

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
 
     let style = ProgressStyle::default_bar()
         .template(
-            "{spinner:.green} [{prefix}] [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len}} ({eta})",
+            "{spinner:.green} [{prefix}] [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len}} ({eta_precise})",
         )
         .with_key("eta", |state| format!("{:.1}s", state.eta().as_secs_f64()))
         .progress_chars("#>-");

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -320,15 +320,18 @@ impl FileManager {
                 ) {
                     break;
                 }
-                if entry.path().is_file() {
-                    let temp_string = entry.path().extension().unwrap().to_str().unwrap();
-                    if allowed_extensions.contains(&temp_string.to_lowercase()) {
-                        let entry_string = entry.into_path();
-                        if !self.existing_files_hashset.contains(&entry_string) {
-                            self.existing_files_hashset.insert(entry_string.clone());
-                            self.new_files_queue.push(entry_string.clone());
-                        };
-                    }
+                
+                if !entry.path().is_file() || entry.path().extension().is_none() {
+                    continue;
+                }
+
+                let temp_string = entry.path().extension().unwrap().to_str().unwrap();
+                if allowed_extensions.contains(&temp_string.to_lowercase()) {
+                    let entry_string = entry.into_path();
+                    if !self.existing_files_hashset.contains(&entry_string) {
+                        self.existing_files_hashset.insert(entry_string.clone());
+                        self.new_files_queue.push(entry_string.clone());
+                    };
                 }
             }
         }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -37,7 +37,12 @@ impl Profile {
     }
 
     pub fn split_profile(&self) -> (Option<i32>, Option<i32>, Option<f64>, Option<f64>) {
-        (Some(self.width as i32), Some(self.height as i32), Some(self.framerate), Some(self.length_time))//lossy casts
+        (
+            Some(self.width as i32),
+            Some(self.height as i32),
+            Some(self.framerate),
+            Some(self.length_time),
+        ) //lossy casts
     }
 }
 


### PR DESCRIPTION
Because we only checked if a file was a regular file
we missed that if tlm tries to import any regular file with no extension
it will panic at an unwrap error so we just check first.
Later this should probably take the files mime type instead